### PR TITLE
Add site map page and update chatbot

### DIFF
--- a/css/map.css
+++ b/css/map.css
@@ -1,0 +1,67 @@
+body {
+    background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
+    min-height: 100vh;
+}
+
+.map-container {
+    max-width: 1000px;
+    margin: 2rem auto;
+    padding: 2rem;
+    background: rgba(255, 255, 255, 0.95);
+    border-radius: 20px;
+    box-shadow: 0 15px 35px rgba(0, 0, 0, 0.1);
+}
+
+.map-section {
+    margin-bottom: 1.5rem;
+}
+
+.map-section h2 {
+    font-size: 1.5rem;
+    margin-bottom: 0.8rem;
+}
+
+.map-section ul {
+    list-style: none;
+    padding-left: 1rem;
+}
+
+.map-section ul li {
+    margin-bottom: 0.6rem;
+}
+
+.map-section ul li a {
+    color: #007bff;
+    text-decoration: none;
+}
+
+.map-section ul li a:hover {
+    text-decoration: underline;
+}
+
+.back-btn {
+    position: fixed;
+    top: 2rem;
+    left: 2rem;
+    padding: 0.8rem 1.5rem;
+    background: white;
+    border: none;
+    border-radius: 25px;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+    color: #007bff;
+    text-decoration: none;
+    transition: all 0.3s ease;
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+}
+
+.back-btn:hover {
+    transform: translateX(-5px);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
+    background: #f8f9fa;
+}
+
+.back-btn i {
+    margin-right: 8px;
+}

--- a/js/chatbot.js
+++ b/js/chatbot.js
@@ -277,10 +277,9 @@ document.addEventListener("DOMContentLoaded", function () {
         广告: 'ads.html',
         简介: 'profile.html',
         博客: 'https://blog.alexander.xin', // 新增博客文章导航
-        React性能优化: 'blog-posts/react-performance.html',
-        UI设计趋势: 'blog-posts/design-trends-2024.html',
-        远程工作: 'blog-posts/remote-work-experience.html',
-        原子习惯: 'blog-posts/atomic-habits-notes.html',
+        地图: "map.html",
+        站点地图: "map.html",
+        网站地图: "map.html",
 
         // 英文导航
         home: '#intro',
@@ -294,10 +293,9 @@ document.addEventListener("DOMContentLoaded", function () {
         ads: 'ads.html',
         profile: 'profile.html',
         blog: 'https://blog.alexander.xin', // 新增英文博客文章导航
-        'react performance': 'blog-posts/react-performance.html',
-        'ui design trends': 'blog-posts/design-trends-2024.html',
-        'remote work': 'blog-posts/remote-work-experience.html',
-        'atomic habits': 'blog-posts/atomic-habits-notes.html',
+        map: "map.html",
+        "site map": "map.html",
+        "page map": "map.html",
     };
 
     // 对话内容库 - 增强版
@@ -315,13 +313,9 @@ document.addEventListener("DOMContentLoaded", function () {
     📍 广告 - 广告服务
     📍 简介 - 个人简介
     📍 博客 - 博客文章
-    
-    博客文章:
-    📝 React性能优化 - React优化技巧
-    📝 UI设计趋势 - 2024设计前瞻
-    📝 远程工作 - 远程工作经验
-    📝 原子习惯 - 读书笔记
-    
+
+    📍 地图 - 网站地图
+
     您可以输入"去xx"或"打开xx"来访问对应页面`,],
 
         greetings: ["你好！我是雪宝，很高兴为您服务！😊", "嗨！今天有什么我可以帮你的吗？✨", "你好啊！我是你的AI助手雪宝，有什么可以帮到你？🌟", "欢迎找我聊天！我可以查询天气、讲笑话，或者帮你导航网站。🤖",],
@@ -333,7 +327,7 @@ document.addEventListener("DOMContentLoaded", function () {
         pageNotFound: ["抱歉，我找不到这个页面呢~ 要不要看看其他内容？", "这个页面好像走丢了，让我带您去别的地方看看吧！",],
         confirmNav: ["好的，让我们出发吧！", "这就带您过去~", "马上就到啦！"],
         searchHelp: ["您可以这样搜索：\n✨ 直接输入关键词\n🔍 '搜索xxx'\n📖 '查找xxx'", "需要帮您找什么吗？告诉我关键词就好~",],
-        tips: ["小贴士：你可以问我'北京天气'来获取天气信息！", "小贴士：输入'讲个笑话'，我会讲一个有趣的笑话！", "小贴士：输入'几点了'可以查看当前时间！", "小贴士：输入'去主页'或类似导航指令可以快速导航网站！", "小贴士：尝试问我'你是谁'来了解我吧！", "小贴士：如果你需要帮助，随时输入'帮助'！",],
+        tips: ["小贴士：你可以问我'北京天气'来获取天气信息！", "小贴士：输入'讲个笑话'，我会讲一个有趣的笑话！", "小贴士：输入'几点了'可以查看当前时间！", "小贴士：输入'去主页'或类似导航指令可以快速导航网站！", "小贴士：尝试问我'你是谁'来了解我吧！", "小贴士：如果你需要帮助，随时输入'帮助'！", "小贴士：输入'地图'可查看网站地图！"],
         funFacts: ["你知道吗？人的大脑每天产生约70,000个想法！", "有趣的是，蜜蜂实际上可以识别人脸！", "你知道吗？笑容会使用17块面部肌肉，而皱眉会使用43块！", "有趣的事实：打喷嚏时你的心脏会短暂停止一瞬间！", "地球上的水与地球形成时的水是相同的，我们喝的可能是恐龙喝过的水！",],
     };
 

--- a/map.html
+++ b/map.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <title>网站地图 - Alexander James Carter</title>
+    <meta name="description" content="快速查看本站主要页面并跳转。">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="css/style.default.css">
+    <link rel="stylesheet" href="css/custom.css">
+    <link rel="stylesheet" href="css/map.css">
+</head>
+<body>
+    <a class="back-btn" href="index.html"><i class="fas fa-arrow-left me-2"></i>返回主页</a>
+    <div class="map-container">
+        <h1>网站地图</h1>
+        <p class="mb-4">以下列出本站主要页面，便于您快速访问。</p>
+        <div class="map-section">
+            <h2>主要页面</h2>
+            <ul>
+                <li><a href="index.html">主页</a></li>
+                <li><a href="zh-CN/gallery.html">作品画廊</a></li>
+                <li><a href="zh-CN/profile.html">个人简介</a></li>
+                <li><a href="zh-CN/contact.html">联系我们</a></li>
+            </ul>
+        </div>
+        <div class="map-section">
+            <h2>工具</h2>
+            <ul>
+                <li><a href="zh-CN/currency.html">货币转换</a></li>
+                <li><a href="zh-CN/calendar.html">智能日历</a></li>
+                <li><a href="time.html">标准时间</a></li>
+            </ul>
+        </div>
+        <div class="map-section">
+            <h2>政策与条款</h2>
+            <ul>
+                <li><a href="zh-CN/privacy.html">隐私政策</a></li>
+                <li><a href="zh-CN/terms.html">使用条款</a></li>
+                <li><a href="zh-CN/ads.html">广告服务</a></li>
+            </ul>
+        </div>
+        <div class="map-section">
+            <h2>其他语言</h2>
+            <ul>
+                <li><a href="en/index-en.html">English</a></li>
+                <li><a href="jp/index-jp.html">日本語</a></li>
+                <li><a href="it/index-it.html">Italiano</a></li>
+            </ul>
+        </div>
+        <div class="map-section">
+            <h2>博客</h2>
+            <ul>
+                <li><a href="https://blog.alexander.xin">博客文章</a></li>
+            </ul>
+        </div>
+    </div>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -46,4 +46,10 @@
         <changefreq>weekly</changefreq>
         <priority>0.9</priority>
     </url>
+    <url>
+        <loc>https://alexander.xin/map.html</loc>
+        <lastmod>2025-04-21T12:00:00+00:00</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.6</priority>
+    </url>
 </urlset>


### PR DESCRIPTION
## Summary
- add new user-facing site map page with links to key pages
- style site map with new map.css
- link the site map in chatbot navigation and tips
- remove references to nonexistent blog posts in chatbot
- include site map in sitemap.xml

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68405fde74808322945ba9ca73ba3184