### PR TITLE
Fix map page links and chatbot navigation

### DIFF
--- a/en/index-en.html
+++ b/en/index-en.html
@@ -791,6 +791,7 @@
                         <a href="privacy-en.html">Privacy Policy</a>
                         <a href="terms-en.html">Terms of Use</a>
                         <a href="ads-en.html">Ad Policy</a>
+                        <a href="../map.html">Site Map</a>
                         <a href="contact-en.html">Contact Us</a>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -788,6 +788,7 @@
                         <a href="zh-CN/privacy.html">隐私政策</a>
                         <a href="zh-CN/terms.html">使用条款</a>
                         <a href="zh-CN/ads.html">广告服务</a>
+                        <a href="map.html">网站地图</a>
                         <a href="zh-CN/contact.html">联系我们</a>
                     </div>
                 </div>

--- a/it/index-it.html
+++ b/it/index-it.html
@@ -773,6 +773,7 @@
                         <a href="privacy-it.html">Politica sulla Privacy</a>
                         <a href="terms-it.html">Termini di Utilizzo</a>
                         <a href="ads-it.html">Politica Pubblicitaria</a>
+                        <a href="../map.html">Mappa del sito</a>
                         <a href="contact-it.html">Contattaci</a>
                     </div>
                 </div>

--- a/jp/index-jp.html
+++ b/jp/index-jp.html
@@ -768,6 +768,7 @@
                         <a href="privacy-jp.html">プライバシーポリシー</a>
                         <a href="terms-jp.html">利用規約</a>
                         <a href="ads-jp.html">広告ポリシー</a>
+                        <a href="../map.html">サイトマップ</a>
                         <a href="contact-jp.html">お問い合わせ</a>
                     </div>
                 </div>

--- a/js/chatbot.js
+++ b/js/chatbot.js
@@ -271,15 +271,15 @@ document.addEventListener("DOMContentLoaded", function () {
         创造: '#services',
         作品: '#portfolio',
         文字: '#text',
-        隐私: 'privacy.html',
-        使用条款: 'terms.html',
-        联系: 'contact.html',
-        广告: 'ads.html',
-        简介: 'profile.html',
+        隐私: 'zh-CN/privacy.html',
+        使用条款: 'zh-CN/terms.html',
+        联系: 'zh-CN/contact.html',
+        广告: 'zh-CN/ads.html',
+        简介: 'zh-CN/profile.html',
         博客: 'https://blog.alexander.xin', // 新增博客文章导航
-        地图: "map.html",
-        站点地图: "map.html",
-        网站地图: "map.html",
+        地图: "/map.html",
+        站点地图: "/map.html",
+        网站地图: "/map.html",
 
         // 英文导航
         home: '#intro',
@@ -287,15 +287,15 @@ document.addEventListener("DOMContentLoaded", function () {
         create: '#services',
         portfolio: '#portfolio',
         text: '#text',
-        privacy: 'privacy.html',
-        terms: 'terms.html',
-        contact: 'contact.html',
-        ads: 'ads.html',
-        profile: 'profile.html',
+        privacy: 'en/privacy-en.html',
+        terms: 'en/terms-en.html',
+        contact: 'en/contact-en.html',
+        ads: 'en/ads-en.html',
+        profile: 'en/profile-en.html',
         blog: 'https://blog.alexander.xin', // 新增英文博客文章导航
-        map: "map.html",
-        "site map": "map.html",
-        "page map": "map.html",
+        map: "/map.html",
+        "site map": "/map.html",
+        "page map": "/map.html",
     };
 
     // 对话内容库 - 增强版


### PR DESCRIPTION
## Summary
- add map page links to site footers
- correct chatbot navigation paths

## Testing
- `python3 -m http.server 8000 >/tmp/http.log 2>&1 &`
- `curl -I http://localhost:8000/map.html`


------
https://chatgpt.com/codex/tasks/task_e_684066ceba9c8322833a8e3ae88b93ba