### PR TITLE
fix: pass Code Quality Prettier checks

### DIFF
--- a/src/components/chrome/Header.astro
+++ b/src/components/chrome/Header.astro
@@ -204,9 +204,13 @@ const mainNavItems: NavItem[] = [
   class="fixed top-0 left-0 right-0 z-50 nav-glass transition-all duration-300"
   id="header"
 >
-  <div class="scroll-indicator" id="scroll-indicator" hidden aria-hidden="true"></div>
+  <div class="scroll-indicator" id="scroll-indicator" hidden aria-hidden="true">
+  </div>
 
-  <nav class="relative z-50 container mx-auto px-4 lg:px-8 py-4" aria-label={lang === 'zh-CN' ? '主导航' : 'Main'}>
+  <nav
+    class="relative z-50 container mx-auto px-4 lg:px-8 py-4"
+    aria-label={lang === 'zh-CN' ? '主导航' : 'Main'}
+  >
     <div class="flex items-center justify-between">
       <!-- Logo -->
       <a

--- a/src/components/chrome/MusicPlayer.astro
+++ b/src/components/chrome/MusicPlayer.astro
@@ -143,8 +143,11 @@
     class="flex items-center justify-between px-4 py-3 cursor-grab active:cursor-grabbing select-none border-b border-[rgb(var(--color-border))]"
   >
     <div class="flex items-center gap-2">
-      <span class="folio-mark !text-[rgb(var(--color-text-tertiary))]">Audio</span>
-      <span class="font-heading font-semibold text-[rgb(var(--color-text-primary))]"
+      <span class="folio-mark !text-[rgb(var(--color-text-tertiary))]"
+        >Audio</span
+      >
+      <span
+        class="font-heading font-semibold text-[rgb(var(--color-text-primary))]"
         >音乐</span
       >
     </div>

--- a/src/components/chrome/StructuredData.astro
+++ b/src/components/chrome/StructuredData.astro
@@ -31,4 +31,4 @@ const structuredData = JSON.stringify(
 );
 ---
 
-<script type="application/ld+json" is:inline set:html={structuredData}></script>
+<script type="application/ld+json" is:inline set:html={structuredData} />

--- a/src/components/templates/AboutTemplate.astro
+++ b/src/components/templates/AboutTemplate.astro
@@ -14,11 +14,7 @@ function resolveHref(href: string) {
 }
 ---
 
-<BaseLayout
-  title={t.title}
-  description={t.subtitle}
-  protectedPage={true}
->
+<BaseLayout title={t.title} description={t.subtitle} protectedPage={true}>
   <PageHero
     folio="Folio I"
     kicker={t.kicker}

--- a/src/components/templates/AccessibilityTemplate.astro
+++ b/src/components/templates/AccessibilityTemplate.astro
@@ -376,7 +376,9 @@ const content = accessibilityData[lang as Lang] || accessibilityData['en-GB'];
             content.features.map((feature: any) => (
               <div class="p-4 bg-primary-500/10 rounded-sm">
                 <div class="flex items-center gap-3 mb-2">
-                  <span class="meta-mono text-sm tracking-widest text-primary-600 dark:text-primary-400">{feature.icon}</span>
+                  <span class="meta-mono text-sm tracking-widest text-primary-600 dark:text-primary-400">
+                    {feature.icon}
+                  </span>
                   <h3 class="text-lg font-bold mb-0">{feature.title}</h3>
                 </div>
                 <p class="text-sm mb-0">{feature.desc}</p>

--- a/src/components/templates/CalendarTemplate.astro
+++ b/src/components/templates/CalendarTemplate.astro
@@ -119,7 +119,12 @@ const content = calendarData[lang as Lang] || calendarData['en-GB'];
 ---
 
 <BaseLayout title={content.title}>
-  <PageHero folio="Folio Calendar" kicker="Tools" title={content.title} description={content.headerDesc} />
+  <PageHero
+    folio="Folio Calendar"
+    kicker="Tools"
+    title={content.title}
+    description={content.headerDesc}
+  />
 
   <!-- Calendar Section -->
   <section class="py-16 container mx-auto px-4 lg:px-8">

--- a/src/components/templates/CurrencyTemplate.astro
+++ b/src/components/templates/CurrencyTemplate.astro
@@ -320,7 +320,12 @@ const content = currencyData[lang as Lang] || currencyData['en-GB'];
 ---
 
 <BaseLayout title={content.title}>
-  <PageHero folio="Folio FX" kicker="Tools" title={content.title} description={content.headerDesc} />
+  <PageHero
+    folio="Folio FX"
+    kicker="Tools"
+    title={content.title}
+    description={content.headerDesc}
+  />
 
   <!-- Currency Rates Section -->
   <section class="py-16 container mx-auto px-4 lg:px-8">
@@ -578,12 +583,12 @@ const content = currencyData[lang as Lang] || currencyData['en-GB'];
             <div class="border border-[rgb(var(--color-border))] bg-[rgb(var(--color-bg-primary))] p-6 rounded-sm">
               <p class="folio-mark mb-3">{String(i + 1).padStart(2, '0')}</p>
               <div>
-                  <h4 class="text-lg font-heading font-bold mb-2 text-[rgb(var(--color-text-primary))]">
-                    {tip.title}
-                  </h4>
-                  <p class="text-sm text-[rgb(var(--color-text-secondary))] leading-relaxed">
-                    {tip.desc}
-                  </p>
+                <h4 class="text-lg font-heading font-bold mb-2 text-[rgb(var(--color-text-primary))]">
+                  {tip.title}
+                </h4>
+                <p class="text-sm text-[rgb(var(--color-text-secondary))] leading-relaxed">
+                  {tip.desc}
+                </p>
               </div>
             </div>
           ))

--- a/src/components/templates/FunTemplate.astro
+++ b/src/components/templates/FunTemplate.astro
@@ -409,9 +409,7 @@ const galleryPath =
     <div class="container mx-auto px-4 lg:px-8">
       <div class="grid md:grid-cols-2 gap-6 max-w-5xl mx-auto">
         <!-- 随机一言 -->
-        <article
-          class="glass-card p-6 md:p-8 reveal"
-        >
+        <article class="glass-card p-6 md:p-8 reveal">
           <div class="flex items-center gap-3 mb-3">
             <h2
               class="text-xl font-heading font-bold text-[rgb(var(--color-text-primary))]"
@@ -462,9 +460,7 @@ const galleryPath =
         </article>
 
         <!-- 随机作品 -->
-        <article
-          class="glass-card p-6 md:p-8 reveal"
-        >
+        <article class="glass-card p-6 md:p-8 reveal">
           <div class="flex items-center gap-3 mb-3">
             <h2
               class="text-xl font-heading font-bold text-[rgb(var(--color-text-primary))]"
@@ -586,9 +582,7 @@ const galleryPath =
 
       <!-- Memory Match Game -->
       <div class="max-w-5xl mx-auto mt-6">
-        <article
-          class="glass-card p-6 md:p-8 reveal"
-        >
+        <article class="glass-card p-6 md:p-8 reveal">
           <div class="flex items-center gap-3 mb-3">
             <h2
               class="text-xl font-heading font-bold text-[rgb(var(--color-text-primary))]"
@@ -652,9 +646,7 @@ const galleryPath =
 
       <!-- Extra mini widgets -->
       <div class="grid md:grid-cols-2 gap-6 max-w-5xl mx-auto mt-6">
-        <article
-          class="glass-card p-6 md:p-8 reveal"
-        >
+        <article class="glass-card p-6 md:p-8 reveal">
           <div class="flex items-center gap-3 mb-3">
             <h2
               class="text-xl font-heading font-bold text-[rgb(var(--color-text-primary))]"
@@ -679,9 +671,7 @@ const galleryPath =
           </button>
         </article>
 
-        <article
-          class="glass-card p-6 md:p-8 reveal"
-        >
+        <article class="glass-card p-6 md:p-8 reveal">
           <div class="flex items-center gap-3 mb-3">
             <h2
               class="text-xl font-heading font-bold text-[rgb(var(--color-text-primary))]"

--- a/src/components/templates/LicenseTemplate.astro
+++ b/src/components/templates/LicenseTemplate.astro
@@ -222,10 +222,7 @@ const licenseData: Record<Lang, any> = {
 const content = licenseData[lang as Lang] || licenseData['en-GB'];
 ---
 
-<BaseLayout
-  title={content.title}
-  description={content.description}
->
+<BaseLayout title={content.title} description={content.description}>
   <div class="container mx-auto px-4 lg:px-8 max-w-3xl pt-28 md:pt-32">
     <a
       href={getLangPath('/')}

--- a/src/components/templates/SecurityAcknowledgmentsTemplate.astro
+++ b/src/components/templates/SecurityAcknowledgmentsTemplate.astro
@@ -288,10 +288,7 @@ const t =
   securityAcknowledgmentsData['en-GB'];
 ---
 
-<BaseLayout
-  title={t.title}
-  description={t.description}
->
+<BaseLayout title={t.title} description={t.description}>
   <div class="container mx-auto px-4 lg:px-8 max-w-3xl pt-28 md:pt-32">
     <a
       href={getLangPath('/')}
@@ -482,7 +479,7 @@ const t =
               <div
                 class="w-16 h-16 bg-green-100 dark:bg-green-900/30 rounded-full flex items-center justify-center mx-auto mb-4"
               >
-                </div>
+              </div>
               <h4
                 class="text-xl font-bold text-[rgb(var(--color-text-primary))] mb-2"
               >

--- a/src/components/templates/SecurityPolicyTemplate.astro
+++ b/src/components/templates/SecurityPolicyTemplate.astro
@@ -649,10 +649,7 @@ const securityPolicyData: Record<Lang, any> = {
 const t = securityPolicyData[lang as Lang] || securityPolicyData['en-GB'];
 ---
 
-<BaseLayout
-  title={t.title}
-  description={t.description}
->
+<BaseLayout title={t.title} description={t.description}>
   <div class="container mx-auto px-4 lg:px-8 max-w-3xl pt-28 md:pt-32">
     <a
       href={getLangPath('/')}

--- a/src/components/templates/TimeTemplate.astro
+++ b/src/components/templates/TimeTemplate.astro
@@ -476,7 +476,10 @@ const relatedTools = [
               worldZones.map((z) => (
                 <li class="flex items-center justify-between gap-3 py-2.5 px-3 rounded-sm hover:bg-[rgb(var(--color-bg-accent))]/50 transition-colors">
                   <div class="flex items-center gap-3 min-w-0">
-                    <span class="meta-mono text-xs tracking-wider text-primary-600 dark:text-primary-400 shrink-0" aria-hidden="true">
+                    <span
+                      class="meta-mono text-xs tracking-wider text-primary-600 dark:text-primary-400 shrink-0"
+                      aria-hidden="true"
+                    >
                       {z.icon}
                     </span>
                     <div class="min-w-0">
@@ -567,7 +570,12 @@ const relatedTools = [
               href={tool.href}
               class="inline-flex items-center gap-2 px-4 py-2.5 rounded-sm bg-[rgb(var(--color-bg-secondary))] hover:bg-primary-500/10 border border-[rgb(var(--color-border))] hover:border-primary-500/30 text-[rgb(var(--color-text-primary))] font-medium transition-colors active:scale-[0.98]"
             >
-              <span class="meta-mono text-xs tracking-wider text-primary-600 dark:text-primary-400" aria-hidden="true">{tool.icon}</span>
+              <span
+                class="meta-mono text-xs tracking-wider text-primary-600 dark:text-primary-400"
+                aria-hidden="true"
+              >
+                {tool.icon}
+              </span>
               {tool.label}
             </a>
           ))

--- a/src/components/templates/VerifyTemplate.astro
+++ b/src/components/templates/VerifyTemplate.astro
@@ -95,7 +95,12 @@ const content = copy[lang] || copy['en-GB'];
   showHeader={true}
   showFooter={true}
 >
-  <PageHero folio="Folio Gate" kicker="Verify" title={content.title} description={content.desc} />
+  <PageHero
+    folio="Folio Gate"
+    kicker="Verify"
+    title={content.title}
+    description={content.desc}
+  />
 
   <section class="pb-24">
     <div class="page-shell">

--- a/src/components/widgets/Calculator.astro
+++ b/src/components/widgets/Calculator.astro
@@ -41,10 +41,7 @@ const calcText = {
 const t = calcText[lang as keyof typeof calcText] || calcText['zh-CN'];
 ---
 
-<div
-  id="calculator"
-  class="calculator-widget glass-card p-6 max-w-xs"
->
+<div id="calculator" class="calculator-widget glass-card p-6 max-w-xs">
   <h3 class="text-lg font-bold mb-4 flex items-center gap-2">
     {t.title}
   </h3>

--- a/src/components/widgets/ColorPicker.astro
+++ b/src/components/widgets/ColorPicker.astro
@@ -71,10 +71,7 @@ const colorText = {
 const t = colorText[lang as keyof typeof colorText] || colorText['zh-CN'];
 ---
 
-<div
-  id="color-picker"
-  class="color-widget glass-card p-6 max-w-md"
->
+<div id="color-picker" class="color-widget glass-card p-6 max-w-md">
   <h3 class="text-lg font-bold mb-6 flex items-center gap-2">
     {t.title}
   </h3>

--- a/src/components/widgets/CountdownTimer.astro
+++ b/src/components/widgets/CountdownTimer.astro
@@ -97,10 +97,7 @@ const t =
   countdownText[lang as keyof typeof countdownText] || countdownText['zh-CN'];
 ---
 
-<div
-  id="countdown-timer"
-  class="countdown-widget glass-card p-6 max-w-md"
->
+<div id="countdown-timer" class="countdown-widget glass-card p-6 max-w-md">
   <h3 class="text-lg font-bold mb-6 flex items-center gap-2">
     <span class="text-2xl">⏱️</span>
     {t.title}

--- a/src/components/widgets/DailyFrame.astro
+++ b/src/components/widgets/DailyFrame.astro
@@ -11,8 +11,20 @@ const { lang = 'zh-CN' } = Astro.props;
 
 type Frame = {
   image: string;
-  title: { 'zh-CN': string; 'zh-TW': string; 'en-GB': string; fr: string; ru: string };
-  note: { 'zh-CN': string; 'zh-TW': string; 'en-GB': string; fr: string; ru: string };
+  title: {
+    'zh-CN': string;
+    'zh-TW': string;
+    'en-GB': string;
+    fr: string;
+    ru: string;
+  };
+  note: {
+    'zh-CN': string;
+    'zh-TW': string;
+    'en-GB': string;
+    fr: string;
+    ru: string;
+  };
   credit?: string;
 };
 
@@ -209,9 +221,16 @@ const framesJson = JSON.stringify(frames);
   data-lang={L}
   data-credit-label={t.credit}
 >
-  <script is:inline type="application/json" data-daily-frames set:html={framesJson} />
+  <script
+    is:inline
+    type="application/json"
+    data-daily-frames
+    set:html={framesJson}
+  />
   <div class="grid md:grid-cols-2 gap-0">
-    <div class="contact-sheet relative aspect-[4/3] md:aspect-auto md:min-h-[280px]">
+    <div
+      class="contact-sheet relative aspect-[4/3] md:aspect-auto md:min-h-[280px]"
+    >
       <span class="contact-sheet-frame">01</span>
       <img
         data-daily-img
@@ -241,7 +260,8 @@ const framesJson = JSON.stringify(frames);
       <p
         class="meta-mono text-xs text-[rgb(var(--color-text-tertiary))] hidden"
         data-daily-credit
-      ></p>
+      >
+      </p>
     </div>
   </div>
 </article>
@@ -291,5 +311,7 @@ const framesJson = JSON.stringify(frames);
     }
   }
 
-  document.querySelectorAll<HTMLElement>('[data-daily-frame]').forEach(applyDailyFrame);
+  document
+    .querySelectorAll<HTMLElement>('[data-daily-frame]')
+    .forEach(applyDailyFrame);
 </script>

--- a/src/components/widgets/ExposureTriangle.astro
+++ b/src/components/widgets/ExposureTriangle.astro
@@ -166,8 +166,11 @@ const isos = ['100', '200', '400', '800', '1600', '3200', '6400'];
       >—</span
     >
   </div>
-  <p class="mt-3 text-xs text-[rgb(var(--color-text-tertiary))] leading-relaxed">
-    <span class="font-heading font-semibold text-[rgb(var(--color-text-secondary))]"
+  <p
+    class="mt-3 text-xs text-[rgb(var(--color-text-tertiary))] leading-relaxed"
+  >
+    <span
+      class="font-heading font-semibold text-[rgb(var(--color-text-secondary))]"
       >{t.tip}</span
     >
     {' '}{t.tipBody}

--- a/src/components/widgets/PasswordGenerator.astro
+++ b/src/components/widgets/PasswordGenerator.astro
@@ -96,10 +96,7 @@ const pwdText = {
 const t = pwdText[lang as keyof typeof pwdText] || pwdText['zh-CN'];
 ---
 
-<div
-  id="password-generator"
-  class="password-widget glass-card p-6 max-w-md"
->
+<div id="password-generator" class="password-widget glass-card p-6 max-w-md">
   <h3 class="text-lg font-bold mb-6 flex items-center gap-2">
     {t.title}
   </h3>

--- a/src/components/widgets/PomodoroTimer.astro
+++ b/src/components/widgets/PomodoroTimer.astro
@@ -66,10 +66,7 @@ const timerText = {
 const t = timerText[lang as keyof typeof timerText] || timerText['zh-CN'];
 ---
 
-<div
-  id="pomodoro-timer"
-  class="pomodoro-widget glass-card p-6 max-w-sm"
->
+<div id="pomodoro-timer" class="pomodoro-widget glass-card p-6 max-w-sm">
   <h3 class="text-lg font-bold mb-6 flex items-center gap-2">
     {t.title}
   </h3>


### PR DESCRIPTION
## Summary
- Code Quality failed on `main` because 20 files (templates/chrome/widgets after the structure move) were not Prettier-formatted.
- This PR runs Prettier on those files so the formatting gate is green again.

## Test plan
- [x] `npx prettier --check` on the 20 previously failing files
- [ ] Confirm Code Quality workflow passes on this PR
- [ ] Spot-check `/`, `/fun`, `/about` still render


Made with [Cursor](https://cursor.com)